### PR TITLE
imgurのログインを実装

### DIFF
--- a/src/plugins/imgur.js
+++ b/src/plugins/imgur.js
@@ -5,7 +5,7 @@ function imgur(config, expire) {
     const apiURL = {
         auth: "https://api.imgur.com/oauth2/authorize",
         token: "https://api.imgur.com/oauth2/token",
-        userInfo: "https://api.imgur.com/3/account/me/block",
+        userInfo: "https://api.imgur.com/3/account/me/settings",
     };
     return new oauth(config, expire, provider, apiURL);
 }

--- a/src/plugins/imgur.js
+++ b/src/plugins/imgur.js
@@ -1,0 +1,13 @@
+const oauth = require("../utill/provider");
+const provider = "imgur";
+
+function imgur(config, expire) {
+    const apiURL = {
+        auth: "https://api.imgur.com/oauth2/authorize",
+        token: "https://api.imgur.com/oauth2/token",
+        userInfo: "https://api.imgur.com/3/account/me/block",
+    };
+    return new oauth(config, expire, provider, apiURL);
+}
+exports = module.exports = imgur;
+exports.provider = provider;


### PR DESCRIPTION
imgur.jsを追加
imgurのログインを実装
developerサイトは[こちら](https://apidocs.imgur.com/)

client idとclient secretの作成は、https://api.imgur.com/oauth2/addclient から
callback : http://localhost:3000/jetoauth/callback/imgur
スコープは空でOK。