### PR TITLE
microsoftを追加

### DIFF
--- a/src/plugins/microsoft.js
+++ b/src/plugins/microsoft.js
@@ -1,0 +1,17 @@
+const oauth = require("../utill/provider");
+const provider = "microsoft";
+
+function microsoft(config, expire) {
+    const apiURL = {
+        auth: `https://login.microsoftonline.com/${
+            config?.tenant_id || "consumers"
+        }/oauth2/v2.0/authorize`,
+        token: `https://login.microsoftonline.com/${
+            config?.tenant_id || "consumers"
+        }/oauth2/v2.0/token`,
+        userInfo: `https://graph.microsoft.com/oidc/userinfo`,
+    };
+    return new oauth(config, expire, provider, apiURL);
+}
+exports = module.exports = microsoft;
+exports.provider = provider;


### PR DESCRIPTION
## Client ID(Application ID)とシークレットの取得

https://portal.azure.com/#home からAzure Active Directoryにアクセス。
「管理」の中にある「アプリの登録」->「新規登録」->「個人用Microsoftアカウントのみ」を選択。
リダイレクトURIに「Web」を選択し、コールバックURLに http://localhost:3000/jetoauth/callback/microsoft
アプリを登録する。

### Client ID(Application ID)

作成したアプリの「概要」にある「アプリケーション (クライアント) ID」が`client_id`となる。

### client_secret

「管理」の「証明書とシークレット」にて「新しいクライアント シークレット」を選択。適当な名前をつけ作成。「値」が`client_secret`となる。

## scope
scope: ["openid", "profile", "email"]